### PR TITLE
Fixed dnf install error.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora:24
 RUN \
     dnf update --assumeyes && \
-    dnf install emacs* && \
+    dnf install --assumeyes emacs* && \
     dnf update --assumeyes && \
     dnf clean all && \
     true


### PR DESCRIPTION
When running dnf install we must always use 'assumeyes' or the install
will fail.

Fixes #1
